### PR TITLE
Upgraded `to-map()` with warnings, support for zero-based indexing & more

### DIFF
--- a/stylesheets/SassyLists/_to-map.scss
+++ b/stylesheets/SassyLists/_to-map.scss
@@ -1,26 +1,45 @@
 // Cast a $list into a map, using indexes as keys
+// Useful for iterating through a list with an index variable:
+// `@each $i, $value in to-map($list)`
+// Indexes start with 1 by default.
 // -------------------------------------------------------------------------------
 // @documentation http://sassylists.com/documentation/#to-map
 // -------------------------------------------------------------------------------
+// @alias `enumerate()`
 // @alias `mapify()`
 // -------------------------------------------------------------------------------
 // @example to-map(a b c d e) => (1: a, 2: b, 3: c, 4: d, 5: e)
 // -------------------------------------------------------------------------------
 // @param $list [List] : list
+// @param $start [Number] : index to start with
 // -------------------------------------------------------------------------------
 // @return [Map]
 
-@function to-map($list) {
-    $result: ();
-
-    @for $i from 1 through length($list) {
-        $result: map-merge($result, ($i: nth($list, $i)));
+@function to-map($list, $start: 1) {
+    @if length($list) == 0 {
+        @warn "Empty list provided for `to-map`/`enumerate`.";
+        @return false;
+    }
+    @if type-of($start) != number {
+        @warn "$start provided to `to-map`/`enumerate` was #{type-of($start)}, but it should be a number.";
+        @return false;
     }
 
-    @return $result;
+    $map: ();
+
+    @for $index from 1 through length($list) {
+        $key: $index + $start - 1;
+        $value: nth($list, $index);
+        $map: map-merge($map, ($key: $value));
+    }
+
+    @return $map;
 }
 
-// Alias
-@function mapify($list) {
-    @return to-map($list);
+// Aliases
+@function enumerate($list, $start: 1) {
+    @return to-map($list, $start);
+}
+@function mapify($list, $start: 1) {
+    @return to-map($list, $start);
 }


### PR DESCRIPTION
> Hey Hugo. ^_^
> 
> I stumbled upon [this](http://csspre.com/loops) and noticed that it lacks the `@each` loop.
> 
> Then i noticed that the example requires an index variable.
> 
> Then i remembered [having solved](https://github.com/sass/sass/issues/996#issuecomment-32000596) this case before.
> 
> Then i decided to have a look whether your SassyLists has this function and didn't find one.
> 
> So i created one for you.
> 
> But before submitting a pull request i decided to have a look into your roadmap and found that the function is already implemented in the `next` branch.
> 
> But my implementation seemed better to me, so i decided to send the pull request anyway.
> 
> Don't hesitate to decline it if you feel so.
> 
> PS I've tested it on SassMeister and it seems to work, but i didn't use this very code in any project. Looks like i've got a suggestion for your roadmap.

---

Upgraded `to-map()`:
- Added warnings against illegal arguments.
- Added optional parameter that allows indexing the resulting map starting with any number, e. g. zero.
- Added an alias `enumerate`, which is how Python folk refer to this feature.
- Expanded the description with my favorite use case:

``` sass
@each $i, $value in enumerate($list)
```
