### PR TITLE
Fixed remove-duplicates alias error

### DIFF
--- a/dist/_SassyLists.scss
+++ b/dist/_SassyLists.scss
@@ -606,8 +606,8 @@
 }
 
 // Alias
-@function unique($list, $recursive: false) {
-  @return remove-duplicates($list, $recursive);
+@function unique($list) {
+  @return remove-duplicates($list);
 }
 // Removes value from $list at index $index
 // -------------------------------------------------------------------------------


### PR DESCRIPTION
Recursive removal is not supported yet in `remove-duplicates` but the alias was sending two arguments causing an error. Thus, removed the second argument in and from the `remove-duplicates()` alias `unique()`.
