### PR TITLE
fixes random function

### DIFF
--- a/stylesheets/SassyLists/_random-value.scss
+++ b/stylesheets/SassyLists/_random-value.scss
@@ -12,7 +12,7 @@
  * @example
  * sl-random-value(a b c)
  * // a
- * 
+ *
  * @return {*}
  */
 
@@ -24,7 +24,7 @@
     @return null;
   }
 
-  @return nth($list, random(length($list) - 1) + 1);
+  @return nth($list, random(length($list)));
 }
 
 /**
@@ -40,7 +40,7 @@
  * @requires sl-random-value
  * @alias sl-random-value
  */
- 
+
 @function sl-luck($list) {
   @return sl-random-value($list);
 }


### PR DESCRIPTION
As mentioned (albeit briefly) in #50, the random function is currently broken :sob: 

Previously, `@function sl-random-value` looked like this:
```
@return nth($list, random(length($list) - 1) + 1);
```

Because this function works by adding 1 to the random number generated between 1 and a maximum value, the lowest possible return for this function is 2.

In addition, the above version will loudly fail if a list has only one item.

So: in it's current form, the function returns a random list item between the 2nd and last, but only if the list has at least two items.

The subtraction and addition seem to be unnecessary; a straight random(length($list))) works just fine, and hits all potential numbers in the list.

The version included in this PR makes it so that the function simply returns a random list item:

```
@return nth($list, random(length($list)));
```