### PR TITLE
fix: Fix libsass 4 call deprecation warning #63

### DIFF
--- a/stylesheets/_SassyLists.scss
+++ b/stylesheets/_SassyLists.scss
@@ -4,6 +4,7 @@
 // Repository: https://github.com/at-import/functions/
 
 @import 'helpers/missing-dependencies';
+@import 'helpers/safe-get-function';
 @import 'helpers/str-compare';
 @import 'helpers/true';
 @import 'helpers/is-number';

--- a/stylesheets/functions/_every.scss
+++ b/stylesheets/functions/_every.scss
@@ -20,10 +20,10 @@
 
 @function sl-every($list, $function, $args...) {
   @each $item in $list {
-    @if not call($function, $item, $args...) {
+    @if not call(sl-safe-get-function($function), $item, $args...) {
       @return false;
-    } 
+    }
   }
-  
+
   @return true;
 }

--- a/stylesheets/functions/_some.scss
+++ b/stylesheets/functions/_some.scss
@@ -21,13 +21,13 @@
 ///
 /// @return {Bool}
 ///
- 
+
 @function sl-some($list, $function, $args...) {
   @each $item in $list {
-    @if call($function, $item, $args...) {
+    @if call(sl-safe-get-function($function), $item, $args...) {
       @return true;
-    } 
+    }
   }
-  
+
   @return false;
 }

--- a/stylesheets/functions/_walk.scss
+++ b/stylesheets/functions/_walk.scss
@@ -18,18 +18,18 @@
 ///
 /// @return {List | Null}
 ///
- 
+
 @function sl-walk($list, $function, $args...) {
   $_: sl-missing-dependencies('sl-to-map', 'sl-to-list');
-  
+
   @if not function-exists($function) {
     @error 'There is no `#{$function}` function for `sl-walk`.';
   }
 
   @each $index, $value in sl-to-map($list) {
     $arguments: join($value, $args);
-    $list: set-nth($list, $index, call($function, $arguments...));
+    $list: set-nth($list, $index, call(sl-safe-get-function($function), $arguments...));
   }
-  
+
   @return sl-to-list($list);
 }

--- a/stylesheets/helpers/_safe-get-function.scss
+++ b/stylesheets/helpers/_safe-get-function.scss
@@ -1,0 +1,28 @@
+// Copyright (c) 2016, Kaelig Deloumeau-Prigent
+// All rights reserved.
+// BSD 2-Clause License
+// https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+
+///
+/// Polyfill for the `get-function` function
+/// @link https://github.com/kaelig/sass-safe-get-function
+/// @link http://sass-lang.com/documentation/Sass/Script/Functions.html#get_function-instance_method
+///
+/// @access private
+///
+/// @param {String} $name - Name of the function
+///
+/// @return {Function|String}
+///
+@function safe-get-function($name) {
+  @if (type-of($name) != 'string') {
+    @error 'The parameter passed to safe-get-function() must be a String. Good: safe-get-function(\'foo\') / Bad: safe-get-function(5).';
+  }
+
+  @if function-exists('get-function') {
+    @return get-function($name);
+  }
+
+  @return $name;
+
+}


### PR DESCRIPTION
Fix the following deprecation warning:
```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("fade")) instead.
```

Call `call()` with a function retrieved by the new function `get-function`.

### Changes:
* add `sl-safe-get-function` polyfill for `get-function` for libsass < 3.5
* use `sl-safe-get-function` for each call of `call()`

Closes https://github.com/at-import/SassyLists/issues/63